### PR TITLE
fix paramtype

### DIFF
--- a/active_nodes.lua
+++ b/active_nodes.lua
@@ -313,6 +313,7 @@ minetest.register_node('waterfalls:basin', {
 	description = S('Waterfall Basin'),
 	tiles       = {'waterfall_basin.png'},
 	walkable    = false,
+	paramtype 	= 'light',
     climbable   = true,
 	groups      = {oddly_breakable_by_hand=3},
 	drowning    = 1,
@@ -519,6 +520,7 @@ minetest.register_node('waterfalls:fountain', {
 	groups          = {oddly_breakable_by_hand=3},
 	sounds          = default.node_sound_stone_defaults(),
     use_texture_alpha = true,
+	paramtype 	= 'light',
 
     on_timer = fountain_timer,
 


### PR DESCRIPTION
Without `paramtype=light` in the definition, the waterfall and fountain nodes show up as black masses while using certain graphics settings (shaders?). 